### PR TITLE
sets Book level object metadata display ON

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -171,6 +171,7 @@ drush_role_remove_perm: []
 #drush_vset_simple: []
 drush_vset_simple:
 - { key: islandora_solution_pack_remote_resource_redirection_type, value: goto }
+- { key: 'islandora_book_metadata_display', value: 1}
 # - { key: islandora_compound_object_use_jail_view, value: 1 }  
 # - { key: islandora_basic_collection_admin_page_size, value: 50 }
 # - { key: islandora_collection_search_advanced_search_alter, value: 1 }


### PR DESCRIPTION
https://trello.com/c/CaIuNMQ4

Vsets book metadata display value to "1".

Tested by ``drush vset islandora_book_metadata_display 1`` on dev box.  Switching between values 0 & 1 resulting in toggling on/off metadata display on the webpage.  Adding the line to the group_vars/all.yml, then running ``vagrant provision`` resulted in the expected outcome.
