### PR TITLE
sets internet archive bookreader to side-by-side view

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -171,6 +171,7 @@ drush_role_remove_perm: []
 #drush_vset_simple: []
 drush_vset_simple:
 - { key: islandora_solution_pack_remote_resource_redirection_type, value: goto }
+- { key: islandora_internet_archive_bookreader_default_page_view, value: '2'}
 # - { key: islandora_compound_object_use_jail_view, value: 1 }  
 # - { key: islandora_basic_collection_admin_page_size, value: 50 }
 # - { key: islandora_collection_search_advanced_search_alter, value: 1 }


### PR DESCRIPTION
I'm not sure the history of this task, but it seemed to have general consensus last I heard.  


vsets the variable "islandora_internet_archive_bookreader_default_page_view" to "2".
Side-by-side page viewing of Book objects.

Vset to "2" results in side-by-side page layout in browser.  Vset "1" results in single-page.  Admin panel at islandora_viewers/internet_archive_bookreader Default Page View updates as expected between "Single Page" and "Side by side".

Adding the line to group_vars/all.yml,  then running ``vagrant provision`` leads to side-by-side viewing of a book object.  Note:  one must exit & reenter the book object for the setting to be applied -- this is an unimportant edge-case.  All books opened in the future open in Side-by-side view. 
